### PR TITLE
Use Spring Boot and Spring Cloud dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,22 +48,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-            <version>${spring.security.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
-            <version>${spring.security.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
             <version>${spring.security.version}</version>
         </dependency>
 
@@ -77,23 +62,6 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
             <version>${openfeign.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-slf4j</artifactId>
-            <version>${openfeign.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-hystrix</artifactId>
-            <version>${openfeign.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -115,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -40,30 +40,43 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <spring.security.version>5.3.5.RELEASE</spring.security.version>
-        <spring.cloud.openfeign.version>2.2.5.RELEASE</spring.cloud.openfeign.version>
-        <openfeign.version>10.10.1</openfeign.version>
+        <spring-boot-dependencies.version>2.6.2</spring-boot-dependencies.version>
+        <spring-cloud-dependencies.version>2021.0.0</spring-cloud-dependencies.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
-            <version>${spring.security.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-openfeign-core</artifactId>
-            <version>${spring.cloud.openfeign.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
-            <version>${openfeign.version}</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-dependencies.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud-dependencies.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>
@@ -92,6 +105,14 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <links>
+                        <!-- It would be better to link to the exact versions of these APIs, but I'm not sure of the
+                        best way to configure the version without making it harder to maintain. -->
+                        <link>https://docs.spring.io/spring-security/site/docs/current/api</link>
+                        <link>https://javadoc.io/static/io.github.openfeign/feign-core/latest</link>
+                    </links>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/loesak/springframework/security/openfeign/oauth2/OAuth2FeignRequestInterceptor.java
+++ b/src/main/java/org/loesak/springframework/security/openfeign/oauth2/OAuth2FeignRequestInterceptor.java
@@ -2,7 +2,6 @@ package org.loesak.springframework.security.openfeign.oauth2;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -13,7 +12,6 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 import java.util.Objects;
 
-@Slf4j
 public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 
     private static final Authentication ANONYMOUS_AUTHENTICATION = new AnonymousAuthenticationToken(


### PR DESCRIPTION
Upgrade to latest spring-boot/spring-cloud versions.
Upgrade the javadoc plugin so that JAVA_HOME env variable is not required.
Remove unneccessary dependencies.